### PR TITLE
Extract friesToFrext() from transform() in FrextFormatter.

### DIFF
--- a/src/main/groovy/org/clulab/frext/FrextFormatter.groovy
+++ b/src/main/groovy/org/clulab/frext/FrextFormatter.groovy
@@ -77,16 +77,24 @@ class FrextFormatter {
       else [:]                              // else JSON was missing in file
     }
 
+    def frextDoc = friesToFrext(docId, friesMap)
+
+    outputDocument(docId, frextDoc)
+    return 1
+  }
+
+  /** Obtain frext output content for a single doc set. */
+  def friesToFrext (docId, friesMap) {
     // extract relevant information from the data structures:
     friesMap['sentences'] = extractSentenceTexts(friesMap)  // must be extracted before others
     friesMap['entities']  = extractEntityMentions(friesMap) // must be extracted before events
     friesMap['events']    = extractEventMentions(friesMap)
 
     // build a new document with the information extracted from the FRIES format
-    def outDoc = getMetaData(docId, friesMap)
-    outDoc['events'] = getEvents(docId, friesMap)
-    outputDocument(docId, outDoc)
-    return 1
+    def frextDoc = getMetaData(docId, friesMap)
+    frextDoc['events'] = getEvents(docId, friesMap)
+
+    return frextDoc
   }
 
   /** Begin the output document for a single paper by adding any metadata. */


### PR DESCRIPTION
Hi there,
Thank you for providing the converter. I need to use it to translate some ```fries``` content to ```frext``` but I do not want to make this transformation through files. Therefore, I needed to refactor ```transform()``` in ```FrextFormatter```. I extracted ```friesToFrext()``` function from ```transform()```. I moved the code segment that creates an output document metadata and attaches events to it using ```getEvents()``` from ```transform()``` to ```friesToFrext()```. Then I called ```friesToFrext()``` inside ```transform()```.

After these changes ```transform()``` works in the same way and there is ```friesToFrext()``` available for the ones who wants to make transformation without needing to have input and output files.