### PR TITLE
Added maven publish support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,12 @@
 plugins {
   id 'groovy'
+  id 'maven-publish'
   id 'application'
   id 'com.github.johnrengelman.shadow' version '1.2.4'
 }
 
 apply plugin: 'groovy'
+apply plugin: 'maven-publish'
 apply plugin: 'application'
 apply plugin: 'com.github.johnrengelman.shadow'
 
@@ -27,8 +29,22 @@ tasks.withType(GroovyCompile) {
 }
 
 mainClassName = 'org.clulab.frext.Frext'
+group = 'org.clulab.frext'
 sourceCompatibility = 1.8
 version = '1.2.1'
+
+publishing {
+  publications {
+    mavenJava(MavenPublication) {
+      from components.java
+    }
+  }
+}
+
+jar {
+  exclude('PMC-files_list.tsv.gz')
+}
+
 
 shadowJar {
   manifest {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'frext'


### PR DESCRIPTION
I think that this converter can provide a library as well as providing a runnable jar. Therefore, this PR is intended to add maven publish support to the converter. 

The following is how I use it as a library in Java

```java
FrextFormatter ff = new FrextFormatter(null);
// reachJson includes entities, events and sentences fields
// I think that docId would be null 
LinkedHashMap frextRes = (LinkedHashMap) ff.friesToFrext(docId, reachJson);
```

One can run ```gradle publishToMavenLocal``` to publish this library to his local maven repository. Then the library will be available by adding the following dependency (for the current version 1.2.1)

```java
        <dependency>
	  	<groupId>org.clulab.frext</groupId>
		<artifactId>frext</artifactId>
		<version>1.2.1</version>
	</dependency>
  ```

I excluded ```PMC-files_list.tsv.gz``` from jar because I think it is only used by main class and would be enough if just included in the shadowJar.

Do you consider publishing the library to a remote maven repository?